### PR TITLE
Run using Docker: add Dockerfile and update README.md

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -201,3 +201,5 @@ dmypy.json
 .venv/
 
 # End of https://www.gitignore.io/api/python,pycharm
+
+.oauthconfig/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,15 @@
+FROM ubuntu:bionic
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+	build-essential \
+	python3 \
+	python3-pip \
+	python3-setuptools \
+	python3-wheel
+
+RUN pip3 install jira-oauth
+COPY .oauthconfig /root/.oauthconfig
+WORKDIR /root
+
+EXPOSE 8080
+CMD jira-oauth

--- a/README.md
+++ b/README.md
@@ -63,5 +63,12 @@ Success!
 Issue key: IDEV-1, Summary: Internal Devepment Issue #1
 ```
 
+## Run with Docker
+
+    cp -R ~/.oauthconfig ./
+    docker build -t jira-oauth .
+    docker run -p 8080:8080 -it --rm jira-oauth
+
+
 ## Credits
 Thank you, Raju Kadam, for implementing https://github.com/rkadam/jira-oauth-generator


### PR DESCRIPTION
jira-oauth seems to not work with Python 3.5 due to aiooauth.  Also it's
broken on Python 3.7 due to a bug in tlslite.  But Python 3.6 works!
So in order to be useful to the most number of folks, here's a docker
setup that uses Python 3.6.